### PR TITLE
Add Travis CI build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: scala
+scala:
+  - 2.10.2-RC1
+jdk:
+   - oraclejdk7
+   - openjdk7
+cache:
+  directories:
+  - $HOME/.ivy2

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Odds
+Odds [![Build Status](https://travis-ci.org/sstucki/odds.png?branch=master)](https://travis-ci.org/sstucki/odds)
 ====
 
 Probabilistic programming in Scala

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.0
+sbt.version=0.13.1


### PR DESCRIPTION
Hi!

I've added a Travis CI configuration that automatically builds and tests odds.
The tests already complete green for [my repository](https://travis-ci.org/nightscape/odds).
I've also added a badge which links to the build success of your repository and should become green once you have merged this PR and performed steps 1,2 and 4 from here:
http://about.travis-ci.org/docs/user/getting-started/

Using Travis CI greatly enhances transparency on the project's status and for me always is a good sign that I can start working on stuff and have a good set of tests that keeps me from doing stupid things :)

Best
  Martin
