### PR TITLE
Fix deprecation warnings.

### DIFF
--- a/core/src/test/scala/odds/CMusicModelTest.scala
+++ b/core/src/test/scala/odds/CMusicModelTest.scala
@@ -34,7 +34,7 @@ trait CMusicModel extends CListOddsLang with Notes {
 
   def transpose(probs: List[Double], n: Int): Note => Rand[Note] = {
     val arr = for (i <- 0 to 11) yield (octave.drop(n+i).zip(probs))
-    (x: Note) => choice(arr(note_to_int(x)) : _*)
+    (x: Note) => choose(arr(note_to_int(x)) : _*)
   }
 
   // pre-compute the transformations
@@ -57,7 +57,7 @@ trait CMusicModel extends CListOddsLang with Notes {
   val id: PTransform[Note] = x => always(x)
   val delete: PTransform[Note] = x => nil
   def choose_op() =
-    choice(
+    choose(
       id -> 0.4,
       delete -> 0.2,
       maptranspose2 -> 0.1,

--- a/core/src/test/scala/odds/CMusicWarmUpModelTest.scala
+++ b/core/src/test/scala/odds/CMusicWarmUpModelTest.scala
@@ -84,34 +84,34 @@ trait CMusicWarmUpModel extends CListOddsLang with Notes {
 
   // Transpose a note by 1 interval
   def transpose1(n: Note) = n match {
-    case C      => choice(Csharp -> 0.3, D -> 0.6, Dsharp -> 0.1)
-    case Csharp => choice(D -> 0.4, Dsharp -> 0.6)
-    case D      => choice(Dsharp -> 0.3, E -> 0.7)
-    case Dsharp => choice(E -> 0.7, F -> 0.3)
-    case E      => choice(F -> 0.6, Fsharp -> 0.4)
-    case F      => choice(Fsharp -> 0.3, G -> 0.6, Gsharp -> 0.1)
-    case Fsharp => choice(G -> 0.4, Gsharp -> 0.6)
-    case G      => choice(Gsharp -> 0.3, A -> 0.6, Asharp -> 0.1)
-    case Gsharp => choice(A -> 0.4, Asharp -> 0.6)
-    case A      => choice(Asharp -> 0.3, B -> 0.7)
-    case Asharp => choice(B -> 0.7, C -> 0.3)
-    case B      => choice(C -> 0.6, Csharp -> 0.4)
+    case C      => choose(Csharp -> 0.3, D -> 0.6, Dsharp -> 0.1)
+    case Csharp => choose(D -> 0.4, Dsharp -> 0.6)
+    case D      => choose(Dsharp -> 0.3, E -> 0.7)
+    case Dsharp => choose(E -> 0.7, F -> 0.3)
+    case E      => choose(F -> 0.6, Fsharp -> 0.4)
+    case F      => choose(Fsharp -> 0.3, G -> 0.6, Gsharp -> 0.1)
+    case Fsharp => choose(G -> 0.4, Gsharp -> 0.6)
+    case G      => choose(Gsharp -> 0.3, A -> 0.6, Asharp -> 0.1)
+    case Gsharp => choose(A -> 0.4, Asharp -> 0.6)
+    case A      => choose(Asharp -> 0.3, B -> 0.7)
+    case Asharp => choose(B -> 0.7, C -> 0.3)
+    case B      => choose(C -> 0.6, Csharp -> 0.4)
   }
 
   // Transpose a note by 5 intervals
   def transpose5(n: Note) = n match {
-    case C      => choice(F -> 0.3, Fsharp -> 0.1, G -> 0.55, Gsharp -> 0.05)
-    case Csharp => choice(Fsharp -> 0.3, G -> 0.4, Gsharp -> 0.3)
-    case D      => choice(G -> 0.3, Gsharp -> 0.1, A -> 0.55, Asharp -> 0.05)
-    case Dsharp => choice(Gsharp -> 0.3, A -> 0.4, Asharp -> 0.3)
-    case E      => choice(A -> 0.3, Asharp -> 0.1, B -> 0.55, C -> 0.05)
-    case F      => choice(Asharp -> 0.1, B -> 0.2, C -> 0.6, Csharp -> 0.1)
-    case Fsharp => choice(B -> 0.3, C -> 0.4, Csharp -> 0.3)
-    case G      => choice(C -> 0.3, Csharp -> 0.1, D -> 0.55, Dsharp -> 0.05)
-    case Gsharp => choice(Csharp -> 0.3, D -> 0.4, Dsharp -> 0.3)
-    case A      => choice(D -> 0.3, Dsharp -> 0.1, E -> 0.55, F -> 0.05)
-    case Asharp => choice(Dsharp -> 0.3, E -> 0.3, F -> 0.4)
-    case B      => choice(E -> 0.3, F -> 0.3, Fsharp -> 0.3, G -> 0.1)
+    case C      => choose(F -> 0.3, Fsharp -> 0.1, G -> 0.55, Gsharp -> 0.05)
+    case Csharp => choose(Fsharp -> 0.3, G -> 0.4, Gsharp -> 0.3)
+    case D      => choose(G -> 0.3, Gsharp -> 0.1, A -> 0.55, Asharp -> 0.05)
+    case Dsharp => choose(Gsharp -> 0.3, A -> 0.4, Asharp -> 0.3)
+    case E      => choose(A -> 0.3, Asharp -> 0.1, B -> 0.55, C -> 0.05)
+    case F      => choose(Asharp -> 0.1, B -> 0.2, C -> 0.6, Csharp -> 0.1)
+    case Fsharp => choose(B -> 0.3, C -> 0.4, Csharp -> 0.3)
+    case G      => choose(C -> 0.3, Csharp -> 0.1, D -> 0.55, Dsharp -> 0.05)
+    case Gsharp => choose(Csharp -> 0.3, D -> 0.4, Dsharp -> 0.3)
+    case A      => choose(D -> 0.3, Dsharp -> 0.1, E -> 0.55, F -> 0.05)
+    case Asharp => choose(Dsharp -> 0.3, E -> 0.3, F -> 0.4)
+    case B      => choose(E -> 0.3, F -> 0.3, Fsharp -> 0.3, G -> 0.1)
   }
 
   val f_ide: PTransform[Note] = x => always(x)
@@ -123,12 +123,12 @@ trait CMusicWarmUpModel extends CListOddsLang with Notes {
     case CCons(headd, tail) =>
       for (
         input <- always(x);
-        f1 <- choice(
+        f1 <- choose(
           f_ide -> 0.5,
           f_del -> 0.2,
           f_tr1 -> 0.2,
           f_tr5 -> 0.1);
-        f2 <- choice(
+        f2 <- choose(
           f_ide -> 0.5,
           f_del -> 0.2,
           f_tr1 -> 0.2,
@@ -158,13 +158,13 @@ class CMusicWarmUpModelExactTest
     val r = normalize(reify(main))
     show(r, "exact main")
     r.toMap foreach {
-      case (G, p)      => p should be (0.002777777 plusOrMinus 1e-9)
-      case (Fsharp, p) => p should be (0.008333333 plusOrMinus 1e-9)
-      case (F, p)      => p should be (0.008333333 plusOrMinus 1e-9)
-      case (E, p)      => p should be (0.008333333 plusOrMinus 1e-9)
-      case (C, p)      => p should be (0.5         plusOrMinus 1e-9)
-      case (Csharp, p) => p should be (0.333333333 plusOrMinus 1e-9)
-      case (B, p)      => p should be (0.138888888 plusOrMinus 1e-9)
+      case (G, p)      => p should be (0.002777777 +- 1e-9)
+      case (Fsharp, p) => p should be (0.008333333 +- 1e-9)
+      case (F, p)      => p should be (0.008333333 +- 1e-9)
+      case (E, p)      => p should be (0.008333333 +- 1e-9)
+      case (C, p)      => p should be (0.5         +- 1e-9)
+      case (Csharp, p) => p should be (0.333333333 +- 1e-9)
+      case (B, p)      => p should be (0.138888888 +- 1e-9)
       case x => throw new Exception("unexpected note: " + x)
     }
   }

--- a/core/src/test/scala/odds/CoinModelTest.scala
+++ b/core/src/test/scala/odds/CoinModelTest.scala
@@ -58,7 +58,7 @@ class CoinModelTest
 
   it should "show the results of coinModel1a" in {
     val coinModel1a = reify(for {
-      coin <- choice(0 -> 0.5, 1 -> 0.5)
+      coin <- choose(0 -> 0.5, 1 -> 0.5)
     } yield {
       val sum1 = coin + coin
       val sum2 = sum1 + coin
@@ -70,7 +70,7 @@ class CoinModelTest
 
   it should "show the results of coinModel1b" in {
     val coinModel1b = reify {
-      val coin = choice(0 -> 0.5, 1 -> 0.5)
+      val coin = choose(0 -> 0.5, 1 -> 0.5)
       val sum1 = coin + coin
       val sum2 = sum1 + coin
       sum2
@@ -81,7 +81,7 @@ class CoinModelTest
 
   it should "show the results of coinModel2a" in {
     val coinModel2a = reify(for {
-      coin <- choice(0 -> 0.5, 1 -> 0.5)
+      coin <- choose(0 -> 0.5, 1 -> 0.5)
     } yield {
       val sum1 = coin + coin
       val sum2 = sum1 + coin
@@ -93,7 +93,7 @@ class CoinModelTest
 
   it should "show the results of coinModel2b" in {
     val coinModel2b = reify {
-      val coin = choice(0 -> 0.5, 1 -> 0.5)
+      val coin = choose(0 -> 0.5, 1 -> 0.5)
       val sum1 = coin + coin
       val sum2 = sum1 + coin
       (sum2 == always(3)) flatMap {

--- a/core/src/test/scala/odds/DrunkCoinModelTest.scala
+++ b/core/src/test/scala/odds/DrunkCoinModelTest.scala
@@ -38,8 +38,8 @@ class DrunkCoinModelTest
       val d = reify(dcoinAnd(10))
       show(d, "dcointAnd(10), exact")
       d foreach {
-        case (false, p) => p should be (5.263157894e-2  plusOrMinus 1e-11)
-        case (true, p) =>  p should be (9.765624999e-14 plusOrMinus 1e-23)
+        case (false, p) => p should be (5.263157894e-2  +- 1e-11)
+        case (true, p) =>  p should be (9.765624999e-14 +- 1e-23)
       }
     }
   }
@@ -49,8 +49,8 @@ class DrunkCoinModelTest
       val d = sample(5000, 4)(dcoinAnd(10))
       show(d, "dcoinAnd(10), local importance sampling")
       d foreach {
-        case (false, p) => p should be (5.263157894e-2  plusOrMinus 1e-4)
-        case (true, p) =>  p should be (9.765624999e-14 plusOrMinus 1e-13)
+        case (false, p) => p should be (5.263157894e-2  +- 1e-4)
+        case (true, p) =>  p should be (9.765624999e-14 +- 1e-13)
       }
     }
   }

--- a/core/src/test/scala/odds/GrassModelSpec.scala
+++ b/core/src/test/scala/odds/GrassModelSpec.scala
@@ -142,8 +142,8 @@ class GrassModelSpec
     show(ds(4), "rain (all IDs unique)")
     ds foreach { d =>
       d foreach {
-        case (false, p) => p should be (0.322  plusOrMinus 1e-12)
-        case (true,  p) => p should be (0.2838 plusOrMinus 1e-12)
+        case (false, p) => p should be (0.322  +- 1e-12)
+        case (true,  p) => p should be (0.2838 +- 1e-12)
       }
     }
   }
@@ -162,8 +162,8 @@ class GrassModelRejectionSamplingSpec
     val d = sample(1000)(grassModel)
     show(d, "rain (rejection sampling)")
     d foreach {
-      case (false, p) => p should be (0.322  plusOrMinus 1e-1)
-      case (true,  p) => p should be (0.2838 plusOrMinus 1e-1)
+      case (false, p) => p should be (0.322  +- 1e-1)
+      case (true,  p) => p should be (0.2838 +- 1e-1)
     }
   }
 }

--- a/core/src/test/scala/odds/MontyHallModelSpec.scala
+++ b/core/src/test/scala/odds/MontyHallModelSpec.scala
@@ -70,8 +70,8 @@ class MontyHallModelSpec
     val d = reify(firstChoiceWins)
     show(d, "first choice wins")
     d foreach {
-      case (true, p)  => p should be (1.0 / 3.0 plusOrMinus 1e-12)
-      case (false, p) => p should be (2.0 / 3.0 plusOrMinus 1e-12)
+      case (true, p)  => p should be (1.0 / 3.0 +- 1e-12)
+      case (false, p) => p should be (2.0 / 3.0 +- 1e-12)
     }
   }
 
@@ -79,8 +79,8 @@ class MontyHallModelSpec
     val d = reify(secondChoiceWins)
     show(d, "second choice wins")
     d foreach {
-      case (true, p)  => p should be (2.0 / 3.0 plusOrMinus 1e-12)
-      case (false, p) => p should be (1.0 / 3.0 plusOrMinus 1e-12)
+      case (true, p)  => p should be (2.0 / 3.0 +- 1e-12)
+      case (false, p) => p should be (1.0 / 3.0 +- 1e-12)
     }
   }
 }
@@ -98,8 +98,8 @@ class MontyHallMonadicModelSpec
     val d = reify(firstChoiceWins)
     show(d, "first choice wins")
     d foreach {
-      case (true, p)  => p should be (1.0 / 3.0 plusOrMinus 1e-12)
-      case (false, p) => p should be (2.0 / 3.0 plusOrMinus 1e-12)
+      case (true, p)  => p should be (1.0 / 3.0 +- 1e-12)
+      case (false, p) => p should be (2.0 / 3.0 +- 1e-12)
     }
   }
 
@@ -107,8 +107,8 @@ class MontyHallMonadicModelSpec
     val d = reify(secondChoiceWins)
     show(d, "second choice wins")
     d foreach {
-      case (true, p)  => p should be (2.0 / 3.0 plusOrMinus 1e-12)
-      case (false, p) => p should be (1.0 / 3.0 plusOrMinus 1e-12)
+      case (true, p)  => p should be (2.0 / 3.0 +- 1e-12)
+      case (false, p) => p should be (1.0 / 3.0 +- 1e-12)
     }
   }
 }

--- a/core/src/test/scala/odds/MusicModelTest.scala
+++ b/core/src/test/scala/odds/MusicModelTest.scala
@@ -50,7 +50,7 @@ trait MusicModel extends ListOddsLang with Notes {
 
   def transpose(probs: List[Double], n: Int): Note => Rand[Note] = {
     val arr = for (i <- 0 to 11) yield (octave.drop(n+i).zip(probs))
-    (x: Note) => choice(arr(note_to_int(x)) : _*)
+    (x: Note) => choose(arr(note_to_int(x)) : _*)
   }
 
   // pre-compute the transformations
@@ -75,7 +75,7 @@ trait MusicModel extends ListOddsLang with Notes {
   val id: PTransform[Note] = x => always(x)
   val delete: PTransform[Note] = x => nil
   def choose_op() =
-    choice(
+    choose(
       id -> 0.4,
       delete -> 0.2,
       maptranspose2 -> 0.1,

--- a/core/src/test/scala/odds/MusicWarmUpModelTest.scala
+++ b/core/src/test/scala/odds/MusicWarmUpModelTest.scala
@@ -49,34 +49,34 @@ trait MusicWarmUpModel extends StreamOddsLang with Notes {
 
   // Transpose a note by 1 interval
   def transpose1(n: Note) = n match {
-    case C      => choice(Csharp -> 0.3, D -> 0.6, Dsharp -> 0.1)
-    case Csharp => choice(D -> 0.4, Dsharp -> 0.6)
-    case D      => choice(Dsharp -> 0.3, E -> 0.7)
-    case Dsharp => choice(E -> 0.7, F -> 0.3)
-    case E      => choice(F -> 0.6, Fsharp -> 0.4)
-    case F      => choice(Fsharp -> 0.3, G -> 0.6, Gsharp -> 0.1)
-    case Fsharp => choice(G -> 0.4, Gsharp -> 0.6)
-    case G      => choice(Gsharp -> 0.3, A -> 0.6, Asharp -> 0.1)
-    case Gsharp => choice(A -> 0.4, Asharp -> 0.6)
-    case A      => choice(Asharp -> 0.3, B -> 0.7)
-    case Asharp => choice(B -> 0.7, C -> 0.3)
-    case B      => choice(C -> 0.6, Csharp -> 0.4)
+    case C      => choose(Csharp -> 0.3, D -> 0.6, Dsharp -> 0.1)
+    case Csharp => choose(D -> 0.4, Dsharp -> 0.6)
+    case D      => choose(Dsharp -> 0.3, E -> 0.7)
+    case Dsharp => choose(E -> 0.7, F -> 0.3)
+    case E      => choose(F -> 0.6, Fsharp -> 0.4)
+    case F      => choose(Fsharp -> 0.3, G -> 0.6, Gsharp -> 0.1)
+    case Fsharp => choose(G -> 0.4, Gsharp -> 0.6)
+    case G      => choose(Gsharp -> 0.3, A -> 0.6, Asharp -> 0.1)
+    case Gsharp => choose(A -> 0.4, Asharp -> 0.6)
+    case A      => choose(Asharp -> 0.3, B -> 0.7)
+    case Asharp => choose(B -> 0.7, C -> 0.3)
+    case B      => choose(C -> 0.6, Csharp -> 0.4)
   }
 
   // Transpose a note by 5 intervals
   def transpose5(n: Note) = n match {
-    case C      => choice(F -> 0.3, Fsharp -> 0.1, G -> 0.55, Gsharp -> 0.05)
-    case Csharp => choice(Fsharp -> 0.3, G -> 0.4, Gsharp -> 0.3)
-    case D      => choice(G -> 0.3, Gsharp -> 0.1, A -> 0.55, Asharp -> 0.05)
-    case Dsharp => choice(Gsharp -> 0.3, A -> 0.4, Asharp -> 0.3)
-    case E      => choice(A -> 0.3, Asharp -> 0.1, B -> 0.55, C -> 0.05)
-    case F      => choice(Asharp -> 0.1, B -> 0.2, C -> 0.6, Csharp -> 0.1)
-    case Fsharp => choice(B -> 0.3, C -> 0.4, Csharp -> 0.3)
-    case G      => choice(C -> 0.3, Csharp -> 0.1, D -> 0.55, Dsharp -> 0.05)
-    case Gsharp => choice(Csharp -> 0.3, D -> 0.4, Dsharp -> 0.3)
-    case A      => choice(D -> 0.3, Dsharp -> 0.1, E -> 0.55, F -> 0.05)
-    case Asharp => choice(Dsharp -> 0.3, E -> 0.3, F -> 0.4)
-    case B      => choice(E -> 0.3, F -> 0.3, Fsharp -> 0.3, G -> 0.1)
+    case C      => choose(F -> 0.3, Fsharp -> 0.1, G -> 0.55, Gsharp -> 0.05)
+    case Csharp => choose(Fsharp -> 0.3, G -> 0.4, Gsharp -> 0.3)
+    case D      => choose(G -> 0.3, Gsharp -> 0.1, A -> 0.55, Asharp -> 0.05)
+    case Dsharp => choose(Gsharp -> 0.3, A -> 0.4, Asharp -> 0.3)
+    case E      => choose(A -> 0.3, Asharp -> 0.1, B -> 0.55, C -> 0.05)
+    case F      => choose(Asharp -> 0.1, B -> 0.2, C -> 0.6, Csharp -> 0.1)
+    case Fsharp => choose(B -> 0.3, C -> 0.4, Csharp -> 0.3)
+    case G      => choose(C -> 0.3, Csharp -> 0.1, D -> 0.55, Dsharp -> 0.05)
+    case Gsharp => choose(Csharp -> 0.3, D -> 0.4, Dsharp -> 0.3)
+    case A      => choose(D -> 0.3, Dsharp -> 0.1, E -> 0.55, F -> 0.05)
+    case Asharp => choose(Dsharp -> 0.3, E -> 0.3, F -> 0.4)
+    case B      => choose(E -> 0.3, F -> 0.3, Fsharp -> 0.3, G -> 0.1)
   }
 
   val f_ide: PTransform[Note] = x => always(x)
@@ -87,12 +87,12 @@ trait MusicWarmUpModel extends StreamOddsLang with Notes {
     if (x.isEmpty) nil else {
       for (
         input <- always(x);
-        f1 <- choice(
+        f1 <- choose(
           f_ide -> 0.5,
           f_del -> 0.2,
           f_tr1 -> 0.2,
           f_tr5 -> 0.1);
-        f2 <- choice(
+        f2 <- choose(
           f_ide -> 0.5,
           f_del -> 0.2,
           f_tr1 -> 0.2,
@@ -141,13 +141,13 @@ class MusicWarmUpModelExactTest
     val r = normalize(reify(main))
     show(r, "exact main")
     r.toMap foreach {
-      case (G, p)      => p should be (0.002777777 plusOrMinus 1e-9)
-      case (Fsharp, p) => p should be (0.008333333 plusOrMinus 1e-9)
-      case (F, p)      => p should be (0.008333333 plusOrMinus 1e-9)
-      case (E, p)      => p should be (0.008333333 plusOrMinus 1e-9)
-      case (C, p)      => p should be (0.5         plusOrMinus 1e-9)
-      case (Csharp, p) => p should be (0.333333333 plusOrMinus 1e-9)
-      case (B, p)      => p should be (0.138888888 plusOrMinus 1e-9)
+      case (G, p)      => p should be (0.002777777 +- 1e-9)
+      case (Fsharp, p) => p should be (0.008333333 +- 1e-9)
+      case (F, p)      => p should be (0.008333333 +- 1e-9)
+      case (E, p)      => p should be (0.008333333 +- 1e-9)
+      case (C, p)      => p should be (0.5         +- 1e-9)
+      case (Csharp, p) => p should be (0.333333333 +- 1e-9)
+      case (B, p)      => p should be (0.138888888 +- 1e-9)
       case x => throw new Exception("unexpected note: " + x)
     }
   }

--- a/core/src/test/scala/odds/RejectionSamplingTest.scala
+++ b/core/src/test/scala/odds/RejectionSamplingTest.scala
@@ -27,7 +27,7 @@ class RejectionSamplingTest
     condCoins should have size (2)
     condCoins foreach {
       case (v, p) =>
-        p should be (0.250 plusOrMinus 0.125)
+        p should be (0.250 +- 0.125)
     }
   }
 
@@ -44,7 +44,7 @@ class RejectionSamplingTest
     splitTrials should have size (4)
     splitTrials foreach {
       case (v, p) =>
-        p should be (0.250 plusOrMinus 0.125)
+        p should be (0.250 +- 0.125)
     }
   }
 
@@ -62,7 +62,7 @@ class RejectionSamplingTest
     magicCoins should have size (2)
     magicCoins foreach {
       case (v, p) =>
-        p should be (0.500 plusOrMinus 250)
+        p should be (0.500 +- 250)
     }
   }
 }

--- a/core/src/test/scala/odds/TrafficModelSpec.scala
+++ b/core/src/test/scala/odds/TrafficModelSpec.scala
@@ -84,8 +84,8 @@ class TrafficModelSpec
     val d = reify(crash(cautiousDriver, aggressiveDriver, trafficLight))
     show(d, "trafficModel1")
     d foreach {
-      case (Crash,   p) => p should be (0.0369 plusOrMinus 1e-11)
-      case (NoCrash, p) => p should be (0.9631 plusOrMinus 1e-11)
+      case (Crash,   p) => p should be (0.0369 +- 1e-11)
+      case (NoCrash, p) => p should be (0.9631 +- 1e-11)
     }
   }
 
@@ -93,8 +93,8 @@ class TrafficModelSpec
     val d = reify(crash(aggressiveDriver, cautiousDriver, trafficLight))
     show(d, "trafficModel2")
     d foreach {
-      case (Crash,   p) => p should be (0.045 plusOrMinus 1e-11)
-      case (NoCrash, p) => p should be (0.955 plusOrMinus 1e-11)
+      case (Crash,   p) => p should be (0.045 +- 1e-11)
+      case (NoCrash, p) => p should be (0.955 +- 1e-11)
     }
   }
 
@@ -102,8 +102,8 @@ class TrafficModelSpec
     val d = reify(crash(aggressiveDriver, aggressiveDriver, trafficLight))
     show(d, "trafficModel3")
     d foreach {
-      case (Crash,   p) => p should be (0.0891 plusOrMinus 1e-11)
-      case (NoCrash, p) => p should be (0.9109 plusOrMinus 1e-11)
+      case (Crash,   p) => p should be (0.0891 +- 1e-11)
+      case (NoCrash, p) => p should be (0.9109 +- 1e-11)
     }
   }
 }


### PR DESCRIPTION
The ScalaTest `plusOrMinus` was deprecated in favor of `+-` and `choice` in favor of `choose`.
The corresponding tests are fixed and green.
